### PR TITLE
fix command not found error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ echo "Get the serial port"
 port=/dev/$(dmesg | grep -m1 "irq = 19" | sed -e 's#.*\(ttyS[0-9]*\) .*#\1#')
 echo "Found PMC module at serial port $port"
 
-if "$(lsof -t $port)" -eq ""; then
+if [ "$(lsof -t $port)"="" ]; then
 	echo "LN1=Installing...\r" > $port
 	echo "LN2=\r" > $port
 fi


### PR DESCRIPTION
On my system the command lsof executed and resulted in 6138. The script tried to execute a program with the name 6138. I think this should fix this:

6138 -eq ''
6138: command not found